### PR TITLE
feat: enable catalog cleanup and configurable ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ WhatsApp → WhatsApp Bot → OpenAI Swarm System → PostgreSQL → Response
 - Arama ve filtreleme
 - Session bazlı saklama
 - Otomatik Cloudflare tunnel linki
+- Saatlik HTML dosya temizliği (1 saatten eski kataloglar kaldırılır)
 
 ### 4. Gelişmiş Sipariş Sistemi
 - Ürün seçimi algılama
@@ -171,7 +172,8 @@ WHATSAPP_PHONE=905306897885
 
 # Server Ports
 ORCHESTRATOR_PORT=3000
-REPLY_SERVER_PORT=3001
+WHATSAPP_WEBHOOK_PORT=3001
+PRODUCT_SERVER_PORT=3005
 CUSTOMER_AGENT_PORT=3003
 SWARM_SERVER_PORT=3007
 
@@ -187,8 +189,9 @@ DB_PASSWORD=your_password
 ```
 
 ### Portlar
-- `3001`: WhatsApp Reply Server
-- `3007`: OpenAI Swarm Multi-Agent System
+- `WHATSAPP_WEBHOOK_PORT` (varsayılan 3001): WhatsApp Reply Server
+- `PRODUCT_SERVER_PORT` (varsayılan 3005): Ürün kataloğu sunucusu
+- `SWARM_SERVER_PORT` (varsayılan 3007): OpenAI Swarm Multi-Agent System
 - `5678`: n8n (isteğe bağlı, kullanılmıyor)
 
 ## 📊 Multi-Agent İş Akışı

--- a/src/core/html-cleanup-service.js
+++ b/src/core/html-cleanup-service.js
@@ -1,36 +1,105 @@
-// HTML Cleanup Service - Stub file
-// This service is currently disabled
+const fs = require('fs');
+const path = require('path');
 
 class HTMLCleanupService {
-    constructor(directory, maxAge, interval) {
+    constructor(directory, maxAgeMinutes, intervalMinutes) {
         this.directory = directory;
-        this.maxAgeMinutes = maxAge;
-        this.intervalMinutes = interval;
+        this.maxAgeMinutes = maxAgeMinutes;
+        this.intervalMinutes = intervalMinutes;
         this.isRunning = false;
+        this.intervalHandle = null;
+        this.totalCleaned = 0;
     }
-    
+
     start() {
-        console.log('[CLEANUP] Service disabled - using manual cleanup');
-        this.isRunning = false;
+        if (this.isRunning) {
+            return;
+        }
+
+        if (!this.directory) {
+            console.warn('[CLEANUP] Skipping start - directory not configured');
+            return;
+        }
+
+        this.isRunning = true;
+        console.log(`[CLEANUP] Service started. Directory: ${this.directory}, interval: ${this.intervalMinutes} minutes, max age: ${this.maxAgeMinutes} minutes`);
+
+        // Run first cleanup immediately, then on interval
+        this._runCleanup();
+        this.intervalHandle = setInterval(() => this._runCleanup(), this.intervalMinutes * 60 * 1000);
     }
-    
+
     stop() {
+        if (this.intervalHandle) {
+            clearInterval(this.intervalHandle);
+            this.intervalHandle = null;
+        }
+
         this.isRunning = false;
+        console.log('[CLEANUP] Service stopped');
     }
-    
+
+    async _runCleanup() {
+        const cutoff = Date.now() - this.maxAgeMinutes * 60 * 1000;
+        let cleanedCount = 0;
+
+        try {
+            if (!fs.existsSync(this.directory)) {
+                console.warn(`[CLEANUP] Directory not found: ${this.directory}`);
+                return;
+            }
+
+            const files = await fs.promises.readdir(this.directory);
+
+            await Promise.all(files.map(async (file) => {
+                if (!file.endsWith('.html')) {
+                    return;
+                }
+
+                const filePath = path.join(this.directory, file);
+
+                try {
+                    const stats = await fs.promises.stat(filePath);
+                    const modifiedTime = stats.mtime.getTime();
+
+                    if (modifiedTime < cutoff) {
+                        await fs.promises.unlink(filePath);
+                        cleanedCount += 1;
+                        console.log(`[CLEANUP] Deleted stale file: ${file}`);
+                    }
+                } catch (error) {
+                    console.error(`[CLEANUP] Failed to process ${file}:`, error.message);
+                }
+            }));
+
+            if (cleanedCount > 0) {
+                this.totalCleaned += cleanedCount;
+                console.log(`[CLEANUP] Removed ${cleanedCount} stale file(s). Total cleaned: ${this.totalCleaned}`);
+            } else {
+                console.log('[CLEANUP] No stale HTML files found');
+            }
+        } catch (error) {
+            console.error('[CLEANUP] Cleanup run failed:', error.message);
+        }
+    }
+
     getStats() {
         return {
             isRunning: this.isRunning,
-            totalCleaned: 0,
+            totalCleaned: this.totalCleaned,
             config: {
                 maxAgeMinutes: this.maxAgeMinutes,
                 intervalMinutes: this.intervalMinutes
             }
         };
     }
-    
+
     triggerCleanup() {
-        console.log('[CLEANUP] Manual cleanup triggered (disabled)');
+        if (!this.isRunning) {
+            console.warn('[CLEANUP] Trigger requested while service stopped - running single cleanup');
+        }
+
+        return this._runCleanup();
     }
 }
 

--- a/src/core/product-list-server-v2.js
+++ b/src/core/product-list-server-v2.js
@@ -10,7 +10,7 @@ const port = process.env.PRODUCT_SERVER_PORT || 3005;
 const HTMLCleanupService = require('./html-cleanup-service');
 
 // Initialize and start cleanup service
-const cleanupService = new HTMLCleanupService(config.paths.productPages, 10, 5); // 10 min max age, 5 min interval
+const cleanupService = new HTMLCleanupService(config.paths.productPages, 60, 60); // 60 min max age, hourly cleanup
 cleanupService.start();
 
 // Static files serving
@@ -62,7 +62,7 @@ app.get('/', (req, res) => {
             <p>Bu server WhatsApp üzerinden gelen ürün sorgularını işler.</p>
             <p>Ürün listesi linki almak için WhatsApp'tan ürün araması yapın.</p>
             <hr>
-            <p>Status: ✅ Aktif | Port: ${process.env.PRODUCT_SERVER_PORT || 3006}</p>
+            <p>Status: ✅ Aktif | Port: ${port}</p>
         </body>
         </html>
     `);

--- a/src/core/whatsapp-webhook-sender.js
+++ b/src/core/whatsapp-webhook-sender.js
@@ -145,7 +145,7 @@ app.post('/send-message', async (req, res) => {
 });
 
 // Reply server'ı başlat
-const REPLY_PORT = 3001;
+const REPLY_PORT = parseInt(config.env.WHATSAPP_WEBHOOK_PORT, 10) || 3001;
 app.listen(REPLY_PORT, () => {
     console.log(`WhatsApp Reply Server: http://localhost:${REPLY_PORT}/send-message`);
 });


### PR DESCRIPTION
## Summary
- implement an HTML cleanup service that tracks execution metrics and deletes stale catalog files
- start the cleanup service from the product list server while reporting the actual configured port on the status page
- allow the WhatsApp reply webhook to read its port from the `WHATSAPP_WEBHOOK_PORT` environment variable with a default fallback
- document the new port environment variables and hourly catalog cleanup in the README

## Testing
- node --check src/core/whatsapp-webhook-sender.js
- node -e "require('./src/core/html-cleanup-service'); console.log('ok')"

------
https://chatgpt.com/codex/tasks/task_b_68d4f2a310d483228648d82a11c5c8a7